### PR TITLE
#10

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -5,15 +5,16 @@ const {
   writeFile,
   loadPackage,
   normalizeVersion,
-  normalizeAuthor
+  normalizeAuthor,
+  stripNamespaceIfExists
 } = require('../lib/utils')
 const { log } = require(require.resolve('@vue/cli-shared-utils'))
 
 module.exports = (api, options, rootOptions) => {
   debug('options', options)
   debug('rootOptions', rootOptions)
-  const { projectName } = rootOptions
-
+  let { projectName } = rootOptions
+  projectName = stripNamespaceIfExists(projectName);
   // basic extending
   api.extendPackage({
     scripts: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,8 +75,7 @@ function normalizeAuthor (_author) {
 
 function stripNamespaceIfExists (name) {
   if (name.indexOf('@') === -1) return name;
-  const forwardSlashIdx = name.indexOf('/') + 1;
-  return name.substr(forwardSlashIdx, name.length - 1);
+  return name.split('/').slice(-1).join('');
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,6 +73,12 @@ function normalizeAuthor (_author) {
   return author
 }
 
+function stripNamespaceIfExists (name) {
+  if (name.indexOf('@') === -1) return name;
+  const forwardSlashIdx = name.indexOf('/') + 1;
+  return name.substr(forwardSlashIdx, name.length - 1);
+}
+
 module.exports = {
   isUndef,
   isObject,
@@ -83,5 +89,6 @@ module.exports = {
   normalizeModuleName,
   normalizeLicense,
   normalizeVersion,
-  normalizeAuthor
+  normalizeAuthor,
+  stripNamespaceIfExists
 }

--- a/tests/unit/generators/core.spec.js
+++ b/tests/unit/generators/core.spec.js
@@ -27,22 +27,7 @@ test('javascript', async () => {
     apply: require('../../../generator'),
     options: {}
   }])
-
-  // check pkg
-  expect(pkg.sideeffects).toBe(false)
-  expect(pkg.main).toBe(`dist/${projectName}.common.js`)
-  expect(pkg.jsdelivr).toBe(`dist/${projectName}.umd.min.js`)
-  expect(pkg.module).toBe(`dist/${projectName}.esm.js`)
-  expect(pkg.unpkg).toBe(`dist/${projectName}.umd.min.js`)
-  const distFiles = [
-    `dist/${projectName}.common.js`,
-    `dist/${projectName}.umd.min.js`,
-    `dist/${projectName}.umd.js`,
-    `dist/${projectName}.esm.js`,
-    'src'
-  ]
-  distFiles.forEach(file => { expect(pkg.files).toContain(file) })
-
+  checkPackageExpectations(pkg, projectName);
   // check files
   const plugin = files['src/index.js']
   expect(plugin).toMatch(`Vue.prototype.$add = (a, b) => {`)
@@ -73,3 +58,41 @@ test('typescript', async () => {
   expect(plugin).toMatch(`import { VueConstructor, PluginObject } from 'vue'`)
   expect(dts).toMatch(`type PluginAddFunction = (a: number, b: number) => number`)
 })
+
+test('javascript with namespace', async () => {
+  const projectName = '@testing/vue-i18n-gen-js';
+  const projectNameNoNamespace = 'vue-i18n-gen-js';
+
+  const { pkg, files } = await generateWithPlugin([{
+    id: '@vue/cli-service',
+    apply: () => {},
+    options: { projectName }
+  }, {
+    id: 'p11n',
+    apply: require('../../../generator'),
+    options: {}
+  }])
+  checkPackageExpectations(pkg, projectNameNoNamespace);
+  // check files
+  const plugin = files['src/index.js']
+  expect(plugin).toMatch(`Vue.prototype.$add = (a, b) => {`)
+})
+
+function checkPackageExpectations (pkg, name) {
+  // check pkg
+  console.log('checking package');
+  expect(pkg.sideeffects).toBe(false)
+  expect(pkg.main).toBe(`dist/${name}.common.js`)
+  expect(pkg.jsdelivr).toBe(`dist/${name}.umd.min.js`)
+  expect(pkg.module).toBe(`dist/${name}.esm.js`)
+  expect(pkg.unpkg).toBe(`dist/${name}.umd.min.js`)
+  const distFiles = [
+    `dist/${name}.common.js`,
+    `dist/${name}.umd.min.js`,
+    `dist/${name}.umd.js`,
+    `dist/${name}.esm.js`,
+    'src'
+  ];
+
+  distFiles.forEach(file => { expect(pkg.files).toContain(file) })
+}


### PR DESCRIPTION
PR for the following issue https://github.com/kazupon/vue-cli-plugin-p11n/issues/10 

Introduced
- stripNamespaceIfExists method, checks for the @ symbol and removes namespaces.
- update generator/index.js to use new method.
- updated tests to cater for name spaced package names.
- moved package checking to checkPackageExpectations method.
