### PR TITLE
prepublish hook -> linting and building, start script as a serve alias

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -18,6 +18,8 @@ module.exports = (api, options, rootOptions) => {
   // basic extending
   api.extendPackage({
     scripts: {
+      'prepublish': 'vue-cli-service lint && vue-cli-service docs --mode build && vue-cli-service build',
+      'start': 'vue-cli-service serve',
       'demo': 'vue-cli-service demo',
       'docs': 'npm run docs:serve',
       'docs:serve': 'vue-cli-service docs --mode serve',

--- a/tests/unit/generators/core.spec.js
+++ b/tests/unit/generators/core.spec.js
@@ -81,6 +81,7 @@ test('javascript with namespace', async () => {
 function checkPackageExpectations (pkg, name) {
   // check pkg
   console.log('checking package')
+  expect(pkg.scripts['prepublish']).toMatch('vue-cli-service lint && vue-cli-service docs --mode build && vue-cli-service build')
   expect(pkg.sideeffects).toBe(false)
   expect(pkg.main).toBe(`dist/${name}.common.js`)
   expect(pkg.jsdelivr).toBe(`dist/${name}.umd.min.js`)


### PR DESCRIPTION
'prepublish' is important. In case you forget to build, you might publish the old ./dist directory to the npm registry

'start' is a convention for me - not important